### PR TITLE
Reduced the amount of logging at the info level

### DIFF
--- a/Sources/PackageSwiftPcapng/Pcapng/Pcapng.swift
+++ b/Sources/PackageSwiftPcapng/Pcapng/Pcapng.swift
@@ -56,7 +56,7 @@ public struct Pcapng: CustomStringConvertible {
                 }
 
                 if let newBlock = PcapngShb(data: data[data.startIndex + position ..< data.startIndex + position + blockLength]) {
-                    Pcapng.logger.info("\(newBlock.description)")
+                    Pcapng.logger.trace("\(newBlock.description)")
                     segments.append(newBlock)
                 }
             case 1:
@@ -65,7 +65,7 @@ public struct Pcapng: CustomStringConvertible {
                     done = true
                     break
                 }
-                Pcapng.logger.info("\(newBlock.description)")
+                Pcapng.logger.trace("\(newBlock.description)")
                 lastSegment.interfaces.append(newBlock)
             case 3:
                 guard let lastSegment = segments.last, let firstInterface = lastSegment.interfaces.first, let newBlock = PcapngSpb(data: data[data.startIndex + position ..< data.startIndex + position + blockLength], snaplen: firstInterface.snaplen) else {
@@ -73,7 +73,7 @@ public struct Pcapng: CustomStringConvertible {
                     done = true
                     break
                 }
-                Pcapng.logger.info("\(newBlock.description)")
+                Pcapng.logger.trace("\(newBlock.description)")
                 lastSegment.packetBlocks.append(newBlock as PcapngPacket)
             case 4:
                 guard let newBlock = PcapngNrb(data: data[data.startIndex + position ..< data.startIndex + position + blockLength]), let lastSegment = segments.last else {
@@ -81,7 +81,7 @@ public struct Pcapng: CustomStringConvertible {
                     done = true
                     break
                 }
-                Pcapng.logger.info("\(newBlock.description)")
+                Pcapng.logger.trace("\(newBlock.description)")
                 lastSegment.nameResolutions.append(newBlock)
             case 5:
                 guard let newBlock = PcapngIsb(data: data[data.startIndex + position ..< data.startIndex + position + blockLength]), let lastSegment = segments.last else {
@@ -89,7 +89,7 @@ public struct Pcapng: CustomStringConvertible {
                     done = true
                     break
                 }
-                Pcapng.logger.info("\(newBlock.description)")
+                Pcapng.logger.trace("\(newBlock.description)")
                 lastSegment.interfaceStatistics.append(newBlock)
             case 6:
                 guard let newBlock = PcapngEpb(data: data[data.startIndex + position ..< data.startIndex + position + blockLength]), let lastSegment = segments.last else {
@@ -97,7 +97,7 @@ public struct Pcapng: CustomStringConvertible {
                     done = true
                     break
                 }
-                Pcapng.logger.info("\(newBlock.description)")
+                Pcapng.logger.trace("\(newBlock.description)")
                 lastSegment.packetBlocks.append(newBlock as PcapngPacket)
             case 0xbad, 0x40000bad:
                 guard let newBlock = PcapngCb(data: data[data.startIndex + position ..< data.startIndex + position + blockLength]), let lastSegment = segments.last else {
@@ -105,10 +105,10 @@ public struct Pcapng: CustomStringConvertible {
                     done = true
                     break
                 }
-                Pcapng.logger.info("\(newBlock.description)")
+                Pcapng.logger.trace("\(newBlock.description)")
                 lastSegment.customBlocks.append(newBlock)
             case 0x80000001:
-                Pcapng.logger.info("Pcapng: Darwin process event block, ignoring")
+                Pcapng.logger.trace("Pcapng: Darwin process event block, ignoring")
                 
             default:
                 Pcapng.logger.error("Pcapng: default case blockType \(blockType)")
@@ -119,7 +119,7 @@ public struct Pcapng: CustomStringConvertible {
         for segment in segments {
             segment.updateDates()
         }
-        Pcapng.logger.info("\(self.description)")
+        Pcapng.logger.trace("\(self.description)")
     }
 
     /**

--- a/Sources/PackageSwiftPcapng/Pcapng/Pcapng.swift
+++ b/Sources/PackageSwiftPcapng/Pcapng/Pcapng.swift
@@ -25,7 +25,7 @@ public struct Pcapng: CustomStringConvertible {
     }
     public init?(data inputData: Data) {
         self.originalData = inputData
-        var data = inputData
+        let data = inputData
         guard data.count >= 28 else {
             Pcapng.logger.error("Pcapng: Insufficient data \(data.count) bytes")
             return nil

--- a/Sources/PackageSwiftPcapng/Pcapng/PcapngCb.swift
+++ b/Sources/PackageSwiftPcapng/Pcapng/PcapngCb.swift
@@ -16,7 +16,7 @@ public struct PcapngCb: CustomStringConvertible {
     // TODO Options
     
     public var description: String {
-        var output = String(format: "PcapngCb blockType 0x%x blockLength %d enterpriseNumber %d customDataCount %d\n",blockType, blockLength, enterpriseNumber, customDataAndOptions.count)
+        let output = String(format: "PcapngCb blockType 0x%x blockLength %d enterpriseNumber %d customDataCount %d\n",blockType, blockLength, enterpriseNumber, customDataAndOptions.count)
         return output
     }
     init?(data: Data, verbose: Bool = false) {

--- a/Sources/PackageSwiftPcapng/Pcapng/PcapngEpb.swift
+++ b/Sources/PackageSwiftPcapng/Pcapng/PcapngEpb.swift
@@ -60,7 +60,7 @@ public class PcapngEpb: CustomStringConvertible, PcapngPacket {
             return nil
         }
         let optionsData = data[data.startIndex + 28 + capturedLength + Pcapng.paddingTo4(capturedLength) ..< data.startIndex + blockLength - 4]
-        Pcapng.logger.info("PcapngEpb options data count \(optionsData.count)")
+        Pcapng.logger.trace("PcapngEpb options data count \(optionsData.count)")
 
         self.options = PcapngOptions.makeOptions(data: optionsData, type: .epb)
 

--- a/Sources/PackageSwiftPcapng/Pcapng/PcapngIdb.swift
+++ b/Sources/PackageSwiftPcapng/Pcapng/PcapngIdb.swift
@@ -48,7 +48,7 @@ public struct PcapngIdb: CustomStringConvertible {
             return nil
         }
         let optionsData = data[data.startIndex + 16 ..< data.startIndex + blockLength - 4]
-        Pcapng.logger.info("PcapngIdb options data count \(optionsData.count)")
+        Pcapng.logger.trace("PcapngIdb options data count \(optionsData.count)")
 
         self.options = PcapngOptions.makeOptions(data: optionsData, type: .idb)
 

--- a/Sources/PackageSwiftPcapng/Pcapng/PcapngIsb.swift
+++ b/Sources/PackageSwiftPcapng/Pcapng/PcapngIsb.swift
@@ -54,7 +54,7 @@ public struct PcapngIsb: CustomStringConvertible {
         }
         self.finalBlockLength = finalBlockLength
         let optionsData = data[data.startIndex + 20 ..< data.startIndex + blockLength - 4]
-        Pcapng.logger.info("PcapngIsb options data count \(optionsData.count)")
+        Pcapng.logger.debug("PcapngIsb options data count \(optionsData.count)")
 
         self.options = PcapngOptions.makeOptions(data: optionsData, type: .isb)
 

--- a/Sources/PackageSwiftPcapng/Pcapng/PcapngNrb.swift
+++ b/Sources/PackageSwiftPcapng/Pcapng/PcapngNrb.swift
@@ -20,10 +20,10 @@ public struct PcapngNrb: CustomStringConvertible {
     public var description: String {
         var output = String(format: "PcapngNrb blockType 0x%x blockLength %d ipv4records %d ipv6records %dx options.count %d\n",blockType, blockLength, ipv4records.keys.count, ipv6records.keys.count, options.count)
         for key in ipv4records.keys {
-            output.append(" \(key) \(ipv4records[key])")
+            output.append(" \(key) \(String(describing: ipv4records[key]))")
         }
         for key in ipv6records.keys {
-            output.append(" \(key) \(ipv6records[key])")
+            output.append(" \(key) \(String(describing: ipv6records[key]))")
         }
         for option in options {
             output.append("  \(option.description)\n)")

--- a/Sources/PackageSwiftPcapng/Pcapng/PcapngNrb.swift
+++ b/Sources/PackageSwiftPcapng/Pcapng/PcapngNrb.swift
@@ -50,7 +50,7 @@ public struct PcapngNrb: CustomStringConvertible {
         let finalBlockLength = Int(Pcapng.getUInt32(data: data.advanced(by: blockLength - 4)))
         self.finalBlockLength = finalBlockLength
         guard finalBlockLength == blockLength else {
-            Pcapng.logger.info("PcapNrb initializer: blockLength \(blockLength) finalBlockLength \(finalBlockLength)")
+            Pcapng.logger.trace("PcapNrb initializer: blockLength \(blockLength) finalBlockLength \(finalBlockLength)")
             return nil
         }
         
@@ -105,7 +105,7 @@ public struct PcapngNrb: CustomStringConvertible {
             }// switch recordType
         }// while !lastRecord
         let optionsData = data[data.startIndex + recordPosition ..< data.startIndex + blockLength - 4]
-        Pcapng.logger.info("PcapngNrb options data count \(optionsData.count)")
+        Pcapng.logger.trace("PcapngNrb options data count \(optionsData.count)")
 
         self.options = PcapngOptions.makeOptions(data: optionsData, type: .nrb)
 

--- a/Sources/PackageSwiftPcapng/Pcapng/PcapngOption.swift
+++ b/Sources/PackageSwiftPcapng/Pcapng/PcapngOption.swift
@@ -78,7 +78,7 @@ public enum PcapngOption: CustomStringConvertible {
         
         
         
-        Pcapng.logger.info("PcapngOption.init code \(code) length \(length) data \(data)")
+        Pcapng.logger.debug("PcapngOption.init code \(code) length \(length) data \(data)")
         switch (type, code) {
         case (_ , 2988):
             let enterprise = Pcapng.getUInt32(data: data.advanced(by: 4))

--- a/Sources/PackageSwiftPcapng/Pcapng/PcapngOptions.swift
+++ b/Sources/PackageSwiftPcapng/Pcapng/PcapngOptions.swift
@@ -17,7 +17,7 @@ public struct PcapngOptions {
             }
             let code = Int(Pcapng.getUInt16(data: data))
             let length = Int(Pcapng.getUInt16(data: data.advanced(by: 2)))
-            Pcapng.logger.info("code \(code) length \(length) startIndex \(data.startIndex)")
+            Pcapng.logger.trace("code \(code) length \(length) startIndex \(data.startIndex)")
             //TODO possible illegal instruction
             let value = data[data.startIndex + 4 ..< data.startIndex + 4 + length]
             if let option = PcapngOption(code: code, length: length, data: value, type: type) {

--- a/Sources/PackageSwiftPcapng/Pcapng/PcapngShb.swift
+++ b/Sources/PackageSwiftPcapng/Pcapng/PcapngShb.swift
@@ -65,7 +65,7 @@ public class PcapngShb: CustomStringConvertible {
             return nil
         }
         let optionsData = data[data.startIndex + 24 ..< data.startIndex + blockLength - 4]
-        Pcapng.logger.info("PcapngShb options data count \(optionsData.count)")
+        Pcapng.logger.trace("PcapngShb options data count \(optionsData.count)")
 
         self.options = PcapngOptions.makeOptions(data: optionsData, type: .shb)
 


### PR DESCRIPTION
Also, I addressed several compiler warnings.
- `var` to `let`
- Default string interpolation to `String(describing:)`

